### PR TITLE
Update to crystal 0.36

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,6 +10,6 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 0.13.0
 
-crystal: 0.34.0
+crystal: 0.36.0
 
 license: MIT

--- a/src/har/post_data.cr
+++ b/src/har/post_data.cr
@@ -26,8 +26,8 @@ module HAR
     )
     end
 
-    def http_params : HTTP::Params
-      HTTP::Params.new.tap do |http_params|
+    def http_params : URI::Params
+      URI::Params.new.tap do |http_params|
         params.try &.each do |param|
           next unless value = param.value
           http_params[param.name] = value
@@ -35,7 +35,7 @@ module HAR
       end
     end
 
-    def http_params=(http_params : HTTP::Params)
+    def http_params=(http_params : URI::Params)
       @params = params = Array(Param).new
       http_params.each do |key, value|
         params[key] = value

--- a/src/har/request.cr
+++ b/src/har/request.cr
@@ -123,8 +123,8 @@ module HAR
       end
     end
 
-    def query_string_http_params : HTTP::Params
-      HTTP::Params.new.tap do |http_params|
+    def query_string_http_params : URI::Params
+      URI::Params.new.tap do |http_params|
         query_string.each do |param|
           http_params[param.name] = param.value
         end


### PR DESCRIPTION
HTTP::Params renamed to URI::Params

I choose not to update the method names because `PostData#params` already exists and that would be the name I would choose. 