### PR TITLE
move testing output to logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ json.entries
 Pretty much done.
 If there is a needed feature please open an issue.
 
+## Testing
+
+To run specs with debugging output you will have to set the `LOG_LEVEL` to debug.
+
+```crystal
+LOG_LEVEL=debug crystal spec
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/NeuraLegion/har/fork )

--- a/spec/har_spec.cr
+++ b/spec/har_spec.cr
@@ -11,6 +11,6 @@ describe HAR do
   it "access some relevant data" do
     file = "#{__DIR__}/data/example.json"
     json = HAR.from_file(file)
-    pp json
+    Log.debug { json.pretty_inspect }
   end
 end


### PR DESCRIPTION
This is a small change to move the testing output to a debug logger.