### PR TITLE
fix: remove headers merging

### DIFF
--- a/spec/har_spec.cr
+++ b/spec/har_spec.cr
@@ -33,4 +33,33 @@ describe HAR do
     headers.should be_a(HTTP::Headers)
     headers["cache-control"].should eq("no-cache,test-cache")
   end
+
+  it "doesn't merge request headers with the same name" do
+    std_request = HTTP::Request.new(
+      method: "GET",
+      resource: "/",
+      headers: HTTP::Headers{
+        "cache-control" => ["no-cache", "test-cache"],
+        "cookie"        => ["id=1", "userId=2; foo=bar"],
+      }
+    )
+    request = HAR::Request.new(std_request)
+    request.headers.size.should eq(4)
+    request.headers.count { |h| h.name == "cookie" }.should eq(2)
+  end
+
+  it "doesn't merge response headers with the same name" do
+    std_response = HTTP::Client::Response.new(
+      status_code: 200,
+      body: "Hello world",
+      headers: HTTP::Headers{
+        "content-type"   => "text/plain",
+        "content-length" => "11",
+        "set-cookie"     => ["foo=bar; domain=example.com", "userId=1; path=/"],
+      }
+    )
+    response = HAR::Response.new(std_response)
+    response.headers.size.should eq(4)
+    response.headers.count { |h| h.name == "set-cookie" }.should eq(2)
+  end
 end

--- a/src/har/request.cr
+++ b/src/har/request.cr
@@ -108,7 +108,9 @@ module HAR
     def http_headers=(http_headers : HTTP::Headers)
       headers.clear
       http_headers.each do |key, values|
-        headers << Header.new(name: key, value: values.join ", ")
+        values.each do |value|
+          headers << Header.new(name: key, value: value)
+        end
       end
     end
 

--- a/src/har/response.cr
+++ b/src/har/response.cr
@@ -120,7 +120,9 @@ module HAR
     def http_headers=(http_headers : HTTP::Headers)
       headers.clear
       http_headers.each do |key, values|
-        headers << Header.new(name: key, value: values.join ", ")
+        values.each do |value|
+          headers << Header.new(name: key, value: value)
+        end
       end
     end
 


### PR DESCRIPTION
It is not allowed to merge multiple HTTP headers into a single HAR::Header with values joined with ", ". The count of objects in `headers` field should be exactly the same as the count of headers in the original HTTP request or response.

Merging headers can create a malformed "Set-Cookie" header with multiple cookies that can't be parsed by Crystal's HTTP::Cookies class and can even raise an exception.