### PR TITLE
fix: change HTTP::Headers generation in Response

### DIFF
--- a/spec/har_spec.cr
+++ b/spec/har_spec.cr
@@ -46,6 +46,16 @@ describe HAR do
     request = HAR::Request.new(std_request)
     request.headers.size.should eq(4)
     request.headers.count { |h| h.name == "cookie" }.should eq(2)
+
+    std_request = request.to_http_request
+    std_request.headers.get("cache-control").size.should eq 2
+    # The cookie headers get normalized when the HTTP::Request is constructed,
+    # so it will always have a single "cookie" header with all cookies in it
+    std_request.headers.get("cookie").size.should eq 1
+    std_request.headers.get("cookie")[0].should contain("id=1")
+    std_request.headers.get("cookie")[0].should contain("userId=2")
+    std_request.headers.get("cookie")[0].should contain("foo=bar")
+    std_request.cookies.size.should eq(3)
   end
 
   it "doesn't merge response headers with the same name" do
@@ -61,5 +71,18 @@ describe HAR do
     response = HAR::Response.new(std_response)
     response.headers.size.should eq(4)
     response.headers.count { |h| h.name == "set-cookie" }.should eq(2)
+
+    std_response = response.to_http_response
+    std_response.headers.get("set-cookie").size.should eq 2
+    std_response.cookies.size.should eq(2)
+    std_response.cookies.count { |c| c.name == "foo" }.should eq(1)
+    std_response.cookies.count { |c| c.name == "userId" }.should eq(1)
+
+    dump = IO::Memory.new
+    std_response.to_io(dump)
+    # The path=/ is added by Crystal when HTTP::Cookies are populated
+    # The case is also changed there
+    dump.to_s.should contain("Set-Cookie: foo=bar; domain=example.com; path=/\r\n")
+    dump.to_s.should contain("Set-Cookie: userId=1; path=/\r\n")
   end
 end

--- a/src/har/request.cr
+++ b/src/har/request.cr
@@ -150,6 +150,7 @@ module HAR
       rescue ex
         Log.warn(exception: ex) { "Invalid cookie: #{cookie.inspect}" }
       end
+      request.cookies.add_request_headers(request.headers)
       request
     end
   end

--- a/src/har/response.cr
+++ b/src/har/response.cr
@@ -112,7 +112,7 @@ module HAR
     def http_headers : HTTP::Headers
       HTTP::Headers.new.tap do |http_headers|
         headers.each do |header|
-          http_headers[header.name] = header.value
+          http_headers.add(header.name, header.value)
         end
       end
     end
@@ -152,6 +152,7 @@ module HAR
       cookies.each do |cookie|
         response.cookies << cookie.to_http_cookie
       end
+      response.cookies.add_response_headers(response.headers)
       response
     end
   end


### PR DESCRIPTION
Multiple Headers with the same name should be added into the HTTP::Headers correctly. Using `[]` to write multiple headers with the same name overwrites the header, leaving only the last one in place. The situation is critical for `Set-Cookie` header, as some cookies may be lost.